### PR TITLE
[Feat] 캘린더뷰 추가

### DIFF
--- a/TodoQuest/TodoQuest.xcodeproj/project.pbxproj
+++ b/TodoQuest/TodoQuest.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		AA9FE1122E422B44001BE493 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = AA9FE1112E422B44001BE493 /* FirebaseAppCheck */; };
 		AA9FE1142E422B44001BE493 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = AA9FE1132E422B44001BE493 /* FirebaseCrashlytics */; };
 		AA9FE1162E422B44001BE493 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = AA9FE1152E422B44001BE493 /* FirebaseFirestore */; };
+		AAF82C582E655E3000E581C7 /* FSCalendar in Frameworks */ = {isa = PBXBuildFile; productRef = AAF82C572E655E3000E581C7 /* FSCalendar */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 				AA9FE1142E422B44001BE493 /* FirebaseCrashlytics in Frameworks */,
 				AA9FE10D2E422AEB001BE493 /* ReactorKit in Frameworks */,
 				AA9FE1022E422AB3001BE493 /* SnapKit in Frameworks */,
+				AAF82C582E655E3000E581C7 /* FSCalendar in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -158,6 +160,7 @@
 				AA9FE1112E422B44001BE493 /* FirebaseAppCheck */,
 				AA9FE1132E422B44001BE493 /* FirebaseCrashlytics */,
 				AA9FE1152E422B44001BE493 /* FirebaseFirestore */,
+				AAF82C572E655E3000E581C7 /* FSCalendar */,
 			);
 			productName = TodoQuest;
 			productReference = AA9FE0C92E422A06001BE493 /* TodoQuest.app */;
@@ -248,6 +251,7 @@
 				AA9FE1062E422AE0001BE493 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				AA9FE10B2E422AEB001BE493 /* XCRemoteSwiftPackageReference "ReactorKit" */,
 				AA9FE10E2E422B44001BE493 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				AAF82C562E655E3000E581C7 /* XCRemoteSwiftPackageReference "FSCalendar" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = AA9FE0CA2E422A06001BE493 /* Products */;
@@ -668,6 +672,14 @@
 				minimumVersion = 12.1.0;
 			};
 		};
+		AAF82C562E655E3000E581C7 /* XCRemoteSwiftPackageReference "FSCalendar" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/WenchaoD/FSCalendar";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.8.4;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -720,6 +732,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA9FE10E2E422B44001BE493 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFirestore;
+		};
+		AAF82C572E655E3000E581C7 /* FSCalendar */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AAF82C562E655E3000E581C7 /* XCRemoteSwiftPackageReference "FSCalendar" */;
+			productName = FSCalendar;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TodoQuest/TodoQuest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TodoQuest/TodoQuest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9fffbff1a135e743df22057bcedab268f9239fb4e65bf2c414adc75e66109b88",
+  "originHash" : "2b736fcbea7576d36f506a14e00293cc13ecccfe751b494aa7d803376a9ec36f",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "b9bf3adac18e6e3059167194aeb632f15a5ba4b2",
         "version" : "12.1.0"
+      }
+    },
+    {
+      "identity" : "fscalendar",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/WenchaoD/FSCalendar",
+      "state" : {
+        "revision" : "0fbdec5172fccb90f707472eeaea4ffe095278f6",
+        "version" : "2.8.4"
       }
     },
     {

--- a/TodoQuest/TodoQuest/Source/AppHelper/CoreData/CoreDataManager.swift
+++ b/TodoQuest/TodoQuest/Source/AppHelper/CoreData/CoreDataManager.swift
@@ -99,3 +99,11 @@ final class CoreDataManager: CoreDataManagable, ReactiveCompatible {
         }
     }
 }
+
+extension Reactive where Base: CoreDataManager {
+    
+    func fetchTodoList() -> Observable<[Todo]> {
+        base.fetch().asObservable()
+    }
+    
+}

--- a/TodoQuest/TodoQuest/Source/AppHelper/CoreData/CoreDataManager.swift
+++ b/TodoQuest/TodoQuest/Source/AppHelper/CoreData/CoreDataManager.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 import CoreData
+import RxSwift
+import RxCocoa
+import ReactorKit
 
 // MARK: - CoreData Protocols
 
@@ -22,7 +25,7 @@ protocol CoreDataManagable: AnyObject {
     var persistentContainer: NSPersistentContainer { get }
     
     func create(with model: Model)
-    func fetch() -> [Entity]
+    func fetch() -> Single<[Entity]>
     func update(_ id: NSManagedObjectID, updateData: Entity)
     func search(_ id: NSManagedObjectID) -> Entity?
     func delete(_ entity: Entity)
@@ -45,7 +48,7 @@ extension CoreDataManagable {
 
 // MARK: - CoreDataManager
 
-final class CoreDataManager: CoreDataManagable {
+final class CoreDataManager: CoreDataManagable, ReactiveCompatible {
     typealias Model = TodoDTO
     typealias Entity = Todo
     
@@ -56,9 +59,11 @@ final class CoreDataManager: CoreDataManagable {
         try? save()
     }
     
-    func fetch() -> [Entity] {
+    func fetch() -> Single<[Entity]> {
         let request: NSFetchRequest<Entity> = Entity.fetchRequest()
-        return (try? context.fetch(request)) ?? []
+        let todoList = try? context.fetch(request)
+        
+        return .just(todoList ?? [])
     }
 
     func update(_ id: NSManagedObjectID, updateData: Entity) {
@@ -88,8 +93,9 @@ final class CoreDataManager: CoreDataManagable {
         
         do {
             try context.save()
+            debugPrint("context saved")
         } catch let error {
-            print("Error saving Core Data: \(error)")
+            debugPrint("Error saving Core Data: \(error)")
         }
     }
 }

--- a/TodoQuest/TodoQuest/Source/AppHelper/Extension/Date+Ext.swift
+++ b/TodoQuest/TodoQuest/Source/AppHelper/Extension/Date+Ext.swift
@@ -1,0 +1,36 @@
+//
+//  Date+Ext.swift
+//  TodoQuest
+//
+//  Created by 장상경 on 9/3/25.
+//
+
+import UIKit
+
+extension Date {
+    
+    func dateFormatToMonthDay() -> String? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM월 dd일"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: self)
+    }
+    
+    func dateFormatToYearMonth() -> String? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: self)
+    }
+    
+    func addMonth(_ value: Int) -> Date {
+        let date = Calendar.current.date(byAdding: .month, value: value, to: self)
+        return date ?? Date()
+    }
+    
+    func addWeek(_ value: Int) -> Date {
+        let date = Calendar.current.date(byAdding: .weekOfMonth, value: value, to: self)
+        return date ?? Date()
+    }
+    
+}

--- a/TodoQuest/TodoQuest/Source/AppHelper/Extension/UIViewController+Ext.swift
+++ b/TodoQuest/TodoQuest/Source/AppHelper/Extension/UIViewController+Ext.swift
@@ -1,0 +1,18 @@
+//
+//  UIViewController+EXT.swift
+//  TodoQuest
+//
+//  Created by 장상경 on 9/3/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+extension Reactive where Base: UIViewController {
+    var viewDidAppear: Observable<Void> {
+        return self.base.rx.methodInvoked(#selector(Base.viewDidAppear))
+            .map { _ in }
+            .asObservable()
+    }
+}

--- a/TodoQuest/TodoQuest/Source/Model/CalendarModel/SectionForDate.swift
+++ b/TodoQuest/TodoQuest/Source/Model/CalendarModel/SectionForDate.swift
@@ -1,0 +1,19 @@
+//
+//  SectionForDate.swift
+//  TodoQuest
+//
+//  Created by 장상경 on 9/2/25.
+//
+
+import Foundation
+
+enum SectionForDate: CaseIterable {
+    case dateSection
+    
+    var sectionTitle: String {
+        switch self {
+        case .dateSection:
+            return "퀘스트 목록"
+        }
+    }
+}

--- a/TodoQuest/TodoQuest/Source/Model/HomeModel/QuestSectionModel.swift
+++ b/TodoQuest/TodoQuest/Source/Model/HomeModel/QuestSectionModel.swift
@@ -23,7 +23,8 @@ enum QuestSection: CaseIterable {
 
 struct QuestItem: Hashable {
     let id = UUID()
-    let quest: String
+    let editDate: Date?
+    let quest: String?
     let check: Bool
     let priority: QuestPriority
 }

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarHeaderView.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarHeaderView.swift
@@ -8,8 +8,13 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class CalendarHeaderView: UIStackView {
+    
+    fileprivate let previousTapped = PublishRelay<Void>()
+    fileprivate let nextTapped = PublishRelay<Void>()
     
     // MARK: - Properties
     
@@ -48,6 +53,37 @@ final class CalendarHeaderView: UIStackView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let hitTest = super.hitTest(point, with: event) else { return nil }
+        
+        if hitTest == self || subviews.contains(hitTest) {
+            let previous = bounds.maxX / 3
+            let next = (bounds.maxX / 3) * 2
+            
+            if point.x <= previous || point.x >= next {
+                return self
+            } else {
+                return nil
+            }
+        }
+        
+        return hitTest
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        
+        let previous = bounds.maxX / 3
+        let next = (bounds.maxX / 3) * 2
+        
+        if location.x <= previous {
+            previousTapped.accept(())
+        } else if location.x >= next {
+            nextTapped.accept(())
+        }
+    }
+    
     // MARK: - Method
     
     func configTitle(_ title: String) {
@@ -78,6 +114,16 @@ private extension CalendarHeaderView {
         }
     }
     
+}
+
+extension Reactive where Base: CalendarHeaderView {
+    var previousTapped: Observable<Void> {
+        base.previousTapped.asObservable()
+    }
+    
+    var nextTapped: Observable<Void> {
+        base.nextTapped.asObservable()
+    }
 }
 
 // MARK: - Preview

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarHeaderView.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarHeaderView.swift
@@ -1,0 +1,88 @@
+//
+//  CalendarHeaderView.swift
+//  TodoQuest
+//
+//  Created by 장상경 on 9/2/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class CalendarHeaderView: UIStackView {
+    
+    // MARK: - Properties
+    
+    private let previousImage = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.image = UIImage(systemName: "chevron.left")
+        $0.backgroundColor = .clear
+        $0.tintColor = .Label.blackLabel
+    }
+    
+    private let nextImage = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.image = UIImage(systemName: "chevron.right")
+        $0.backgroundColor = .clear
+        $0.tintColor = .Label.blackLabel
+    }
+    
+    private let title = UILabel().then {
+        $0.font = .SCDream(size: 24, weight: .bold)
+        $0.numberOfLines = 1
+        $0.textColor = .Label.blackLabel
+        $0.textAlignment = .center
+        $0.backgroundColor = .clear
+    }
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Method
+    
+    func configTitle(_ title: String) {
+        self.title.text = title
+    }
+    
+}
+
+// MARK: - UI Setting Method
+
+private extension CalendarHeaderView {
+    
+    func setupUI() {
+        axis = .horizontal
+        distribution = .fill
+        backgroundColor = .clear
+        
+        [previousImage, title, nextImage].forEach {
+            addArrangedSubview($0)
+        }
+        
+        title.snp.makeConstraints {
+            $0.width.equalToSuperview().multipliedBy(0.6).priority(.high)
+        }
+        
+        nextImage.snp.makeConstraints {
+            $0.width.equalTo(previousImage)
+        }
+    }
+    
+}
+
+// MARK: - Preview
+
+@available(iOS 17.0, *)
+#Preview {
+    CalendarHeaderView()
+}

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarView.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarView.swift
@@ -14,24 +14,6 @@ import RxCocoa
 
 final class CalendarView: FSCalendar {
     
-    // MARK: - Reactive Properties
-    
-    fileprivate let selectedDateEvent = PublishRelay<Date>()
-    
-    // MARK: - Properties
-    
-    /// 이벤트가 새롭게 설정되면, 이전 이벤트와 비교하여 새로운 값만 이벤트 reload
-    var events: [Date] = [] {
-        didSet {
-            guard oldValue != events else { return }
-            let filteredEvent = events.filter { !oldValue.contains($0) }
-            
-            filteredEvent.forEach {
-                _ = calendar(self, numberOfEventsFor: $0)
-            }
-        }
-    }
-    
     // MARK: - Initializer
     
     override init(frame: CGRect) {
@@ -47,11 +29,10 @@ final class CalendarView: FSCalendar {
     
     // MARK: - Override Function
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        rowHeight = bounds.width / 7
-        weekdayHeight = rowHeight
+    override func setCurrentPage(_ currentPage: Date, animated: Bool) {
+        scrollEnabled = true
+        super.setCurrentPage(currentPage, animated: animated)
+        scrollEnabled = false
     }
     
 }
@@ -67,11 +48,8 @@ private extension CalendarView {
         locale = Locale(identifier: "ko_KR")
         formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         placeholderType = .fillHeadTail
-        scrollEnabled = true
-        headerHeight = 0
-        delegate = self
-        dataSource = self
-        
+        scrollEnabled = false
+        headerHeight = 0        
         setCurrentPage(Date(), animated: false)
         select(Date())
     }
@@ -80,7 +58,7 @@ private extension CalendarView {
         appearance.weekdayFont = .SCDream(size: 16, weight: .medium)
         appearance.weekdayTextColor = .Label.darkLabel
         
-        appearance.titleFont = .SCDream(size: 16, weight: .regular)
+        appearance.titleFont = .SCDream(size: 14, weight: .regular)
         appearance.titleDefaultColor = .CustomColors.blueGray
         appearance.titleTodayColor = .CustomColors.personal
         appearance.titlePlaceholderColor = .View.lightGrayBody
@@ -95,30 +73,6 @@ private extension CalendarView {
         appearance.eventSelectionColor = .CustomColors.personal
     }
     
-}
-
-// MARK: - CalendarView Delegate&DataSource
-
-extension CalendarView: FSCalendarDelegate, FSCalendarDataSource {
-    
-    func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
-        let todayEvent = events.filter { Calendar.current.isDate($0, equalTo: date, toGranularity: .day) }
-        
-        return min(todayEvent.count, 3)
-    }
-    
-    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-        selectedDateEvent.accept(date)
-    }
-    
-}
-
-// MARK: - CalendarView Reactive Extension
-
-extension Reactive where Base: CalendarView {
-    var selectedDate: Observable<Date> {
-        base.selectedDateEvent.asObservable()
-    }
 }
 
 // MARK: - Preview

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarView.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarView.swift
@@ -1,0 +1,129 @@
+//
+//  CalendarView.swift
+//  TodoQuest
+//
+//  Created by 장상경 on 9/2/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+import FSCalendar
+import RxSwift
+import RxCocoa
+
+final class CalendarView: FSCalendar {
+    
+    // MARK: - Reactive Properties
+    
+    fileprivate let selectedDateEvent = PublishRelay<Date>()
+    
+    // MARK: - Properties
+    
+    /// 이벤트가 새롭게 설정되면, 이전 이벤트와 비교하여 새로운 값만 이벤트 reload
+    var events: [Date] = [] {
+        didSet {
+            guard oldValue != events else { return }
+            let filteredEvent = events.filter { !oldValue.contains($0) }
+            
+            filteredEvent.forEach {
+                _ = calendar(self, numberOfEventsFor: $0)
+            }
+        }
+    }
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupAppearance()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Override Function
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        rowHeight = bounds.width / 7
+        weekdayHeight = rowHeight
+    }
+    
+}
+
+// MARK: - CalendarView Private Method
+
+private extension CalendarView {
+    
+    func setupUI() {
+        backgroundColor = .clear
+        firstWeekday = 1
+        allowsMultipleSelection = false
+        locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        placeholderType = .fillHeadTail
+        scrollEnabled = true
+        headerHeight = 0
+        delegate = self
+        dataSource = self
+        
+        setCurrentPage(Date(), animated: false)
+        select(Date())
+    }
+    
+    func setupAppearance() {
+        appearance.weekdayFont = .SCDream(size: 16, weight: .medium)
+        appearance.weekdayTextColor = .Label.darkLabel
+        
+        appearance.titleFont = .SCDream(size: 16, weight: .regular)
+        appearance.titleDefaultColor = .CustomColors.blueGray
+        appearance.titleTodayColor = .CustomColors.personal
+        appearance.titlePlaceholderColor = .View.lightGrayBody
+        
+        appearance.selectionColor = .CustomColors.personal
+        appearance.borderRadius = 0.5
+        
+        appearance.todayColor = .clear
+        appearance.todaySelectionColor = .CustomColors.personal
+        
+        appearance.eventDefaultColor = .CustomColors.personal
+        appearance.eventSelectionColor = .CustomColors.personal
+    }
+    
+}
+
+// MARK: - CalendarView Delegate&DataSource
+
+extension CalendarView: FSCalendarDelegate, FSCalendarDataSource {
+    
+    func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
+        let todayEvent = events.filter { Calendar.current.isDate($0, equalTo: date, toGranularity: .day) }
+        
+        return min(todayEvent.count, 3)
+    }
+    
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        selectedDateEvent.accept(date)
+    }
+    
+}
+
+// MARK: - CalendarView Reactive Extension
+
+extension Reactive where Base: CalendarView {
+    var selectedDate: Observable<Date> {
+        base.selectedDateEvent.asObservable()
+    }
+}
+
+// MARK: - Preview
+
+@available(iOS 17.0, *)
+#Preview {
+    CalendarView()
+}

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
@@ -82,7 +82,7 @@ private extension CalendarViewController {
     }
     
     func setupLayout() {
-        [calendarHeader, calendarView, questListView, indicator].forEach {
+        [calendarHeader, questListView, calendarView, indicator].forEach {
             view.addSubview($0)
         }
         
@@ -92,20 +92,29 @@ private extension CalendarViewController {
             $0.height.equalTo(32)
         }
         
-        calendarView.snp.makeConstraints {
-            $0.top.equalTo(calendarHeader.snp.bottom)
+        questListView.snp.makeConstraints {
             $0.directionalHorizontalEdges.equalTo(calendarHeader)
-            $0.height.equalTo(view.safeAreaLayoutGuide).multipliedBy(0.4)
+            $0.bottom.equalToSuperview()
+            $0.height.greaterThanOrEqualTo(view.safeAreaLayoutGuide).multipliedBy(0.4)
         }
         
-        questListView.snp.makeConstraints {
-            $0.top.equalTo(calendarView.snp.bottom).offset(24)
-            $0.directionalHorizontalEdges.equalTo(calendarView)
-            $0.bottom.equalToSuperview()
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(calendarHeader.snp.bottom).offset(8)
+            $0.directionalHorizontalEdges.equalTo(calendarHeader)
+            $0.bottom.equalTo(questListView.snp.top)
+            self.calendarHeightConstraint = $0.height.equalTo(400).constraint
         }
         
         indicator.snp.makeConstraints {
             $0.directionalEdges.equalToSuperview()
+        }
+    }
+    
+    func changeCalendarScope(_ isWeek: Bool) {
+        if isWeek {
+            calendarView.setScope(.week, animated: true)
+        } else {
+            calendarView.setScope(.month, animated: true)
         }
     }
     
@@ -165,6 +174,10 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
         selectedDateEvent.accept(date)
     }
     
+    func calendar(_ calendar: FSCalendar, boundingRectWillChange bounds: CGRect, animated: Bool) {
+        calendarHeightConstraint?.update(offset: bounds.height)
+    }
+    
 }
 
 // MARK: - CalendarVC Reactor
@@ -172,6 +185,9 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
 extension CalendarViewController: View {
     
     func bind(reactor: CalendarReactor) {
+        
+        // MARK: - Output
+        
         reactor.state.map(\.isLoading)
             .distinctUntilChanged()
             .bind(to: indicator.rx.isAnimating)
@@ -184,9 +200,42 @@ extension CalendarViewController: View {
             .withUnretained(self)
             .bind { owner, items in
                 owner.applySnapShot(items)
-                debugPrint("updateSnapshot")
             }
             .disposed(by: disposeBag)
+        
+        reactor.state.compactMap(\.headerTitle)
+            .distinctUntilChanged()
+            .withUnretained(self)
+            .bind { owner, title in
+                owner.calendarHeader.configTitle(title)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state.map(\.currentPage)
+            .distinctUntilChanged()
+            .withUnretained(self)
+            .bind { owner, date in
+                owner.calendarView.setCurrentPage(date, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state.map(\.allItems)
+            .distinctUntilChanged()
+            .withUnretained(self)
+            .bind { owner, items in
+                owner.events = items.compactMap { $0.editDate }
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state.map(\.calendarScopeIsWeek)
+            .distinctUntilChanged()
+            .withUnretained(self)
+            .bind { owner, isWeek in
+                owner.changeCalendarScope(isWeek)
+            }
+            .disposed(by: disposeBag)
+        
+        // MARK: - Input
         
         Observable.just(.fetchTodoList)
             .bind(to: reactor.action)
@@ -195,6 +244,37 @@ extension CalendarViewController: View {
         selectedDateEvent
             .distinctUntilChanged()
             .map { .selectedDate($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        Observable.merge(
+            calendarHeader.rx.nextTapped.map { [weak self] _ in
+                if let self, self.calendarView.scope == .month {
+                    return self.calendarView.currentPage.addMonth(1)
+                } else if let self, self.calendarView.scope == .week {
+                    return self.calendarView.currentPage.addWeek(1)
+                } else {
+                    return Date()
+                }
+            },
+            calendarHeader.rx.previousTapped.map { [weak self] _ in
+                if let self, self.calendarView.scope == .month {
+                    return self.calendarView.currentPage.addMonth(-1)
+                } else if let self, self.calendarView.scope == .week {
+                    return self.calendarView.currentPage.addWeek(-1)
+                } else {
+                    return Date()
+                }
+            }
+        )
+        .distinctUntilChanged()
+        .map { .changeCurrentPage($0) }
+        .bind(to: reactor.action)
+        .disposed(by: disposeBag)
+        
+        questListView.rx.contentOffset
+            .distinctUntilChanged()
+            .map { .changeScrollOffset($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
@@ -1,0 +1,174 @@
+//
+//  CalendarViewController.swift
+//  TodoQuest
+//
+//  Created by 장상경 on 9/1/25.
+//
+
+import UIKit
+import Then
+import SnapKit
+import RxSwift
+import RxCocoa
+import ReactorKit
+
+final class CalendarViewController: UIViewController {
+    
+    // MARK: - Rx Properties
+    
+    var disposeBag = DisposeBag()
+    
+    // MARK: - Properties
+    
+    private var dataSource: DataSource!
+    
+    // MARK: - UI Components
+    
+    private let indicator = UIActivityIndicatorView().then {
+        $0.style = .large
+        $0.color = .white
+        $0.backgroundColor = .black.withAlphaComponent(0.3)
+    }
+    
+    private let calendarHeader = CalendarHeaderView()
+    private let calendarView = CalendarView()
+    private let questListView = QuestListView().then {
+        $0.contentInset.bottom = 100
+    }
+    
+    // MARK: - Override Method
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupUI()
+    }
+    
+}
+
+// MARK: - UI Setting Method
+
+private extension CalendarViewController {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+        setupDataSource()
+        applySnapShot([])
+    }
+    
+    func configureSelf() {
+        view.backgroundColor = .Background.background
+        questListView.delegate = self
+    }
+    
+    func setupLayout() {
+        [calendarHeader, calendarView, questListView, indicator].forEach {
+            view.addSubview($0)
+        }
+        
+        calendarHeader.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(20)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(32)
+        }
+        
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(calendarHeader.snp.bottom)
+            $0.directionalHorizontalEdges.equalTo(calendarHeader)
+            $0.height.equalTo(view.safeAreaLayoutGuide).multipliedBy(0.4)
+        }
+        
+        questListView.snp.makeConstraints {
+            $0.top.equalTo(calendarView.snp.bottom).offset(24)
+            $0.directionalHorizontalEdges.equalTo(calendarView)
+            $0.bottom.equalToSuperview()
+        }
+        
+        indicator.snp.makeConstraints {
+            $0.directionalEdges.equalToSuperview()
+        }
+    }
+    
+}
+
+// MARK: - CalenarVC TableView DataSource&SnapShot
+
+private extension CalendarViewController {
+    typealias DataSource = UITableViewDiffableDataSource<SectionForDate, QuestItem>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<SectionForDate, QuestItem>
+    
+    func setupDataSource() {
+        dataSource = .init(tableView: questListView, cellProvider: { tableView, indexPath, item in
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: QuestCell.id, for: indexPath) as? QuestCell else { return UITableViewCell(style: .default, reuseIdentifier: nil)}
+            
+            cell.configCell(item.quest, item.check, item.priority)
+            
+            return cell
+        })
+        
+    }
+    
+    func applySnapShot(_ items: [QuestItem]) {
+        var snapshot = Snapshot()
+        snapshot.appendSections(SectionForDate.allCases)
+        snapshot.appendItems(items)
+        
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+}
+
+// MARK: - TableView Delegate - Header Setting
+extension CalendarViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let section = dataSource.sectionIdentifier(for: section) else { return nil }
+        
+        let headerView = QuestHeaderView(section.sectionTitle)
+        
+        return headerView
+    }
+    
+}
+
+// MARK: - CalendarVC Reactor
+
+extension CalendarViewController: View {
+    
+    func bind(reactor: CalendarReactor) {
+        reactor.state.map(\.isLoading)
+            .distinctUntilChanged()
+            .bind(to: indicator.rx.isAnimating)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map(\.selectTodoList)
+            .skip(until: self.rx.viewDidAppear)
+            .take(until: self.rx.deallocated)
+            .distinctUntilChanged()
+            .withUnretained(self)
+            .bind { owner, items in
+                owner.applySnapShot(items)
+                debugPrint("updateSnapshot")
+            }
+            .disposed(by: disposeBag)
+        
+        Observable.just(.fetchTodoList)
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        calendarView.rx.selectedDate
+            .distinctUntilChanged()
+            .map { .selectedDate($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+    }
+    
+}
+
+// MARK: - CalendarVC Preview
+
+@available(iOS 17.0, *)
+#Preview {
+    CalendarViewController()
+}

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
@@ -138,6 +138,7 @@ private extension CalendarViewController {
     }
     
     func applySnapShot(_ items: [QuestItem]) {
+        questListView.backgroundView?.isHidden = !items.isEmpty
         var snapshot = Snapshot()
         snapshot.appendSections(SectionForDate.allCases)
         snapshot.appendItems(items)

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
@@ -11,16 +11,32 @@ import SnapKit
 import RxSwift
 import RxCocoa
 import ReactorKit
+import FSCalendar
 
 final class CalendarViewController: UIViewController {
     
     // MARK: - Rx Properties
     
     var disposeBag = DisposeBag()
+    private let selectedDateEvent = PublishRelay<Date>()
     
     // MARK: - Properties
     
     private var dataSource: DataSource!
+    
+    /// 이벤트가 새롭게 설정되면, 이전 이벤트와 비교하여 새로운 값만 이벤트 reload
+    private var events: [Date] = [] {
+        didSet {
+            guard oldValue != events else { return }
+            let filteredEvent = events.filter { !oldValue.contains($0) }
+            
+            filteredEvent.forEach {
+                _ = calendar(calendarView, numberOfEventsFor: $0)
+            }
+        }
+    }
+    
+    private var calendarHeightConstraint: Constraint?
     
     // MARK: - UI Components
     
@@ -31,7 +47,10 @@ final class CalendarViewController: UIViewController {
     }
     
     private let calendarHeader = CalendarHeaderView()
-    private let calendarView = CalendarView()
+    private lazy var calendarView = CalendarView().then {
+        $0.delegate = self
+        $0.dataSource = self
+    }
     private let questListView = QuestListView().then {
         $0.contentInset.bottom = 100
     }
@@ -132,6 +151,22 @@ extension CalendarViewController: UITableViewDelegate {
     
 }
 
+// MARK: - CalendarView Delegate&DataSource
+
+extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
+    
+    func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
+        let todayEvent = events.filter { Calendar.current.isDate($0, equalTo: date, toGranularity: .day) }
+        
+        return min(todayEvent.count, 3)
+    }
+    
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        selectedDateEvent.accept(date)
+    }
+    
+}
+
 // MARK: - CalendarVC Reactor
 
 extension CalendarViewController: View {
@@ -157,7 +192,7 @@ extension CalendarViewController: View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        calendarView.rx.selectedDate
+        selectedDateEvent
             .distinctUntilChanged()
             .map { .selectedDate($0) }
             .bind(to: reactor.action)

--- a/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
+++ b/TodoQuest/TodoQuest/Source/View/Calendar/CalendarViewController.swift
@@ -102,7 +102,7 @@ private extension CalendarViewController {
             $0.top.equalTo(calendarHeader.snp.bottom).offset(8)
             $0.directionalHorizontalEdges.equalTo(calendarHeader)
             $0.bottom.equalTo(questListView.snp.top)
-            self.calendarHeightConstraint = $0.height.equalTo(400).constraint
+            self.calendarHeightConstraint = $0.height.equalTo(300).constraint
         }
         
         indicator.snp.makeConstraints {

--- a/TodoQuest/TodoQuest/Source/View/Home/HomeViewController.swift
+++ b/TodoQuest/TodoQuest/Source/View/Home/HomeViewController.swift
@@ -11,21 +11,6 @@ import SnapKit
 
 final class HomeViewController: UIViewController {
     
-    // TODO: Test, MockData
-    let todayQuest: [QuestItem] = [
-        .init(quest: "영어 단어 암기", check: false, priority: .P0),
-        .init(quest: "운동하기", check: false, priority: .P1),
-        .init(quest: "독서하기", check: false, priority: .P2),
-        .init(quest: "은행 다녀오기", check: false, priority: .P3)
-    ]
-    
-    let completeQuest: [QuestItem] = [
-        .init(quest: "아침밥 먹기", check: true, priority: .P0),
-        .init(quest: "노트 구매", check: true, priority: .P1),
-        .init(quest: "택배 보내기", check: true, priority: .P2),
-        .init(quest: "교통카드 충전", check: true, priority: .P3),
-    ]
-    
     private var dataSource: DataSource!
     
     private let profileView = MainProfileView()
@@ -119,8 +104,8 @@ private extension HomeViewController {
     func applyInitialSnapShot() {
         var snapshot = Snapshot()
         snapshot.appendSections(QuestSection.allCases)
-        snapshot.appendItems(todayQuest, toSection: .todayQuest)
-        snapshot.appendItems(completeQuest, toSection: .completeQuest)
+        snapshot.appendItems([], toSection: .todayQuest)
+        snapshot.appendItems([], toSection: .completeQuest)
         
         dataSource.apply(snapshot, animatingDifferences: false)
     }

--- a/TodoQuest/TodoQuest/Source/View/Home/HomeViewController.swift
+++ b/TodoQuest/TodoQuest/Source/View/Home/HomeViewController.swift
@@ -37,6 +37,11 @@ final class HomeViewController: UIViewController {
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
+        let inset = view.safeAreaInsets.bottom > 0 ? 116 : 88
+        addButton.snp.updateConstraints {
+            $0.bottom.equalToSuperview().inset(inset)
+        }
+        
         DispatchQueue.main.async {
             self.profileView.layer.shadowPath = self.profileView.shadowPath
             self.addButton.layer.shadowPath = UIBezierPath(roundedRect: self.addButton.bounds, cornerRadius: self.addButton.bounds.height / 2).cgPath

--- a/TodoQuest/TodoQuest/Source/View/Home/QuestCell.swift
+++ b/TodoQuest/TodoQuest/Source/View/Home/QuestCell.swift
@@ -54,7 +54,7 @@ final class QuestCell: UITableViewCell {
         contentView.addBottomBorderWithShapeLayer(with: .View.lightGrayBody, and: 2)
     }
     
-    func configCell(_ quest: String, _ complete: Bool, _ priority: QuestPriority) {
+    func configCell(_ quest: String?, _ complete: Bool, _ priority: QuestPriority) {
         questLabel.text = quest
         priorityLabel.text = priority.rawValue
         priorityLabel.backgroundColor = priority.priorityColor
@@ -62,6 +62,11 @@ final class QuestCell: UITableViewCell {
         if complete {
             checkBox.setImage(UIImage(systemName: "checkmark.square.fill"), for: .normal)
             checkBox.tintColor = .CustomColors.personal
+            priorityLabel.isHidden = true
+        } else {
+            checkBox.setImage(UIImage(systemName: "square"), for: .normal)
+            checkBox.tintColor = .CustomColors.blueGray
+            priorityLabel.isHidden = false
         }
     }
     

--- a/TodoQuest/TodoQuest/Source/View/Home/QuestHeaderView.swift
+++ b/TodoQuest/TodoQuest/Source/View/Home/QuestHeaderView.swift
@@ -19,7 +19,7 @@ final class QuestHeaderView: UILabel {
         font = .SCDream(size: 20, weight: .bold)
         textColor = .Label.blackLabel
         textAlignment = .left
-        backgroundColor = .clear
+        backgroundColor = .Background.background
         numberOfLines = 1
     }
     

--- a/TodoQuest/TodoQuest/Source/View/Home/QuestListView.swift
+++ b/TodoQuest/TodoQuest/Source/View/Home/QuestListView.swift
@@ -11,6 +11,15 @@ import SnapKit
 
 final class QuestListView: UITableView {
     
+    private let emptyLabel = UILabel().then {
+        $0.text = "퀘스트가 없습니다."
+        $0.font = .SCDream(size: 16, weight: .medium)
+        $0.textColor = .Label.grayLabel
+        $0.numberOfLines = 1
+        $0.textAlignment = .center
+        $0.backgroundColor = .clear
+    }
+    
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
         backgroundColor = .clear
@@ -18,6 +27,8 @@ final class QuestListView: UITableView {
         separatorInset = .init(top: 0, left: 8, bottom: 0, right: 8)
         showsVerticalScrollIndicator = false
         showsHorizontalScrollIndicator = false
+        backgroundView = emptyLabel
+        backgroundView?.isHidden = true
         rowHeight = 40
         register(QuestCell.self, forCellReuseIdentifier: QuestCell.id)
     }

--- a/TodoQuest/TodoQuest/Source/View/MainViewController.swift
+++ b/TodoQuest/TodoQuest/Source/View/MainViewController.swift
@@ -19,7 +19,13 @@ final class MainViewController: UIViewController {
         $0.backgroundColor = .clear
     }
     
-    private let mainTab = MainTabBarController([HomeViewController(), SecondVC(), ThirdVC()])
+    private let manager = CoreDataManager()
+    
+    private let homeVC = HomeViewController()
+    private let calendarVC = CalendarViewController()
+    private let profileVC = ThirdVC()
+    
+    private lazy var mainTab = MainTabBarController([homeVC, calendarVC, profileVC])
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,6 +42,7 @@ private extension MainViewController {
     func setupUI() {
         configureSelf()
         setupChildVC()
+        setupReactor()
     }
     
     func configureSelf() {
@@ -68,23 +75,13 @@ private extension MainViewController {
         }
     }
     
+    func setupReactor() {
+        calendarVC.reactor = CalendarReactor(repo: manager)
+    }
+    
 }
 
 // TODO: Test ViewControllers
-class FirstVC: UIViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = .red
-    }
-}
-
-class SecondVC: UIViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = .blue
-    }
-}
-
 class ThirdVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/TodoQuest/TodoQuest/Source/View/Tab/MainTabBarController.swift
+++ b/TodoQuest/TodoQuest/Source/View/Tab/MainTabBarController.swift
@@ -61,6 +61,11 @@ final class MainTabBarController: UIViewController {
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
+        let bgHeight = view.safeAreaInsets.bottom > 0 ? 100 : 72
+        backgroundView.snp.updateConstraints {
+            $0.height.equalTo(bgHeight)
+        }
+        
         DispatchQueue.main.async {
             self.backgroundView.layer.shadowPath = self.backgroundView.shadowPath
         }

--- a/TodoQuest/TodoQuest/Source/ViewModel/CalendarReactor.swift
+++ b/TodoQuest/TodoQuest/Source/ViewModel/CalendarReactor.swift
@@ -14,8 +14,6 @@ final class CalendarReactor: Reactor {
     let initialState: State = State()
     private let manager: CoreDataManager
     
-    private var allItems: [QuestItem] = []
-    
     init(repo: CoreDataManager) {
         self.manager = repo
     }
@@ -58,8 +56,13 @@ final class CalendarReactor: Reactor {
             newState.selectTodoList = items.filter { Calendar.current.isDate($0.editDate ?? Date(), equalTo: defaultDate, toGranularity: .day) }
             
         case .selectedTodoList(let date):
-            newState.selectTodoList = state.allItems.filter { Calendar.current.isDate($0.editDate ?? Date(), equalTo: date, toGranularity: .day) }
-            debugPrint("filtered load items count: \(newState.selectTodoList.count)")
+            let selectItems = state.allItems.filter {
+                Calendar.current.isDate($0.editDate ?? Date(), equalTo: date, toGranularity: .day)
+            }.sorted { first, _ in first.check }
+            
+            newState.selectTodoList = selectItems
+            debugPrint("filtered load items count: \(selectItems.count)")
+            
         }
         
         return newState
@@ -71,18 +74,25 @@ extension CalendarReactor {
     enum Action {
         case fetchTodoList
         case selectedDate(Date)
+        case changeCurrentPage(Date)
+        case changeScrollOffset(CGPoint)
     }
     
     enum Mutation {
         case setLoading(Bool)
         case setAllItems([Todo])
         case selectedTodoList(Date)
+        case setCurrentPage(Date)
+        case setCalendarScale(CGPoint)
     }
     
     struct State {
         var allItems: [QuestItem] = []
         var selectTodoList: [QuestItem] = []
+        var currentPage: Date = Date()
+        var headerTitle: String? = Date().dateFormatToYearMonth()
         var isLoading: Bool = false
+        var calendarScopeIsWeek: Bool = false
     }
     
 }

--- a/TodoQuest/TodoQuest/Source/ViewModel/CalendarReactor.swift
+++ b/TodoQuest/TodoQuest/Source/ViewModel/CalendarReactor.swift
@@ -1,0 +1,88 @@
+//
+//  CalendarReactor.swift
+//  TodoQuest
+//
+//  Created by 장상경 on 9/2/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import ReactorKit
+
+final class CalendarReactor: Reactor {
+    let initialState: State = State()
+    private let manager: CoreDataManager
+    
+    private var allItems: [QuestItem] = []
+    
+    init(repo: CoreDataManager) {
+        self.manager = repo
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .fetchTodoList:
+            return .concat(
+                .just(.setLoading(true)),
+                manager.rx.fetchTodoList().map { .setAllItems($0) },
+                .just(.setLoading(false))
+            )
+            
+        case .selectedDate(let date):
+            return .just(.selectedTodoList(date))
+
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+        case .setLoading(let isLoading):
+            newState.isLoading = isLoading
+            
+        case .setAllItems(let todo):
+            let items = todo.map {
+                QuestItem(editDate: $0.date,
+                          quest: $0.quest,
+                          check: $0.isClear,
+                          priority: QuestPriority.allCases[Int($0.priority)]
+                )
+            }
+            newState.allItems = items
+            
+            debugPrint("load items count: \(items.count)")
+            
+            let defaultDate = Date()
+            newState.selectTodoList = items.filter { Calendar.current.isDate($0.editDate ?? Date(), equalTo: defaultDate, toGranularity: .day) }
+            
+        case .selectedTodoList(let date):
+            newState.selectTodoList = state.allItems.filter { Calendar.current.isDate($0.editDate ?? Date(), equalTo: date, toGranularity: .day) }
+            debugPrint("filtered load items count: \(newState.selectTodoList.count)")
+        }
+        
+        return newState
+    }
+}
+
+extension CalendarReactor {
+    
+    enum Action {
+        case fetchTodoList
+        case selectedDate(Date)
+    }
+    
+    enum Mutation {
+        case setLoading(Bool)
+        case setAllItems([Todo])
+        case selectedTodoList(Date)
+    }
+    
+    struct State {
+        var allItems: [QuestItem] = []
+        var selectTodoList: [QuestItem] = []
+        var isLoading: Bool = false
+    }
+    
+}

--- a/TodoQuest/TodoQuest/Source/ViewModel/CalendarReactor.swift
+++ b/TodoQuest/TodoQuest/Source/ViewModel/CalendarReactor.swift
@@ -30,6 +30,11 @@ final class CalendarReactor: Reactor {
         case .selectedDate(let date):
             return .just(.selectedTodoList(date))
 
+        case .changeCurrentPage(let date):
+            return .just(.setCurrentPage(date))
+            
+        case .changeScrollOffset(let point):
+            return .just(.setCalendarScale(point))
         }
     }
     
@@ -63,6 +68,16 @@ final class CalendarReactor: Reactor {
             newState.selectTodoList = selectItems
             debugPrint("filtered load items count: \(selectItems.count)")
             
+        case .setCurrentPage(let date):
+            newState.currentPage = date
+            newState.headerTitle = date.dateFormatToYearMonth()
+            
+        case .setCalendarScale(let point):
+            if point.y >= 200 {
+                newState.calendarScopeIsWeek = true
+            } else {
+                newState.calendarScopeIsWeek = false
+            }
         }
         
         return newState


### PR DESCRIPTION
## 요약
- 캘린더뷰 구현
- 캘린더뷰 Reactor 연동
- `FSCalendar` 라이브러리 추가
- 일부 공용 뷰 속성 수정

## 작업 상세 내용
FSCalendar를 통해 캘린더뷰 화면을 구현하고, Reactor를 활용하여 이벤트를 연결.
코어데이터로부터 Todo를 불러오고, 이를 필터링하며 이벤트를 표시 및 테이블뷰 업데이트.
테이블뷰를 일정 이상 스크롤 할 경우 캘린더의 크기가 month <-> week 로 변동.

## 스크린샷
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-04 at 16 25 22" src="https://github.com/user-attachments/assets/b8e5b096-8974-4583-9f5a-66b9156713f6" />
